### PR TITLE
Fix duplicate test method name

### DIFF
--- a/django_xlsform_validator/tests.py
+++ b/django_xlsform_validator/tests.py
@@ -313,7 +313,7 @@ class SpreadsheetValidationTests(TestCase):
         self.assertEqual(response.data["result"], "valid")
         self.assertNotIn("errors", response.data)
 
-    def test_highlighted_excel_download(self):
+    def test_highlighted_excel_download_invalid(self):
         """
         Test downloading highlighted Excel file for invalid spreadsheet.
         """


### PR DESCRIPTION
## Summary
- rename the first highlighted Excel download test to `test_highlighted_excel_download_invalid`
- keep the second test in place

## Testing
- `pytest django_xlsform_validator/tests.py::SpreadsheetValidationTests::test_highlighted_excel_download_invalid -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_683e81b311f883268fb67ac3a8e4fa36