### PR TITLE
Use JavaRosa to validate and generate instances

### DIFF
--- a/django_xlsform_validator/serializers.py
+++ b/django_xlsform_validator/serializers.py
@@ -3,7 +3,9 @@ Serializers for the XLSForm validator API.
 """
 
 from rest_framework import serializers
+
 from . import app_settings
+from .validation import ERROR_VALUE_REQUIRED, ERROR_CONSTRAINT_UNSATISFIED
 
 
 class SpreadsheetValidationSerializer(serializers.Serializer):
@@ -72,7 +74,7 @@ class ValidationErrorSerializer(serializers.Serializer):
         help_text="Column number in the original spreadsheet."
     )
     error_type = serializers.CharField(
-        help_text="Type of error: 'type_mismatch', 'error_constraint_unsatisfied', or 'error_value_required'."
+        help_text=f"Type of error: 'type_mismatch', '{ERROR_CONSTRAINT_UNSATISFIED}', or '{ERROR_VALUE_REQUIRED}'."
     )
     error_explanation = serializers.CharField(
         help_text="Human-readable explanation of the error."
@@ -82,6 +84,7 @@ class ValidationErrorSerializer(serializers.Serializer):
     )
     constraint_message = serializers.CharField(
         required=False,
+        allow_null=True,
         help_text="Custom constraint message from XLSForm if available."
     )
 

--- a/django_xlsform_validator/views.py
+++ b/django_xlsform_validator/views.py
@@ -2,16 +2,17 @@
 Views for the XLSForm validator API.
 """
 
-from django.shortcuts import render
-from django.http import FileResponse, Http404
-from rest_framework import viewsets, status
-from rest_framework.response import Response
-from rest_framework.parsers import MultiPartParser, FormParser
-from rest_framework.decorators import action
-import os
-import uuid
 import base64
 import io
+import os
+import uuid
+
+from django.http import FileResponse, Http404
+from django.shortcuts import render
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework.response import Response
 
 from . import app_settings
 from .serializers import SpreadsheetValidationSerializer, ValidationResultSerializer
@@ -49,7 +50,7 @@ class SpreadsheetValidationViewSet(viewsets.ViewSet):
 
         validator = XLSFormValidator()
 
-        if not validator.parse_xlsform(xlsform_file):
+        if not validator.parse_xlsform(xlsform_file, version):
             return Response(
                 {
                     "result": "invalid",
@@ -73,11 +74,7 @@ class SpreadsheetValidationViewSet(viewsets.ViewSet):
 
             if generate_xml:
                 try:
-                    xml_generator = validator.generate_xml_from_spreadsheet(
-                        spreadsheet_file, version, skip_validation=True
-                    )
-                    xml_files = list(xml_generator)
-                    response_data["xml_files"] = xml_files
+                    response_data["xml_files"] = list(map(lambda x: x["xml"], result["valides"]))
                 except Exception as e:
                     return Response(
                         {

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -3,3 +3,4 @@ djangorestframework
 pyxform==2.0.3
 elementpath>=5.0.1
 pandas
+openpyxl

--- a/xlsform_validator/odk_validate/__init__.py
+++ b/xlsform_validator/odk_validate/__init__.py
@@ -1,0 +1,80 @@
+"""
+odk_validate.py
+A python wrapper around ODK Validate
+"""
+
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING
+
+from xlsform_validator.odk_validate.utils import (
+    XFORM_SPEC_PATH,
+    check_readable,
+    run_popen_with_timeout,
+)
+
+if TYPE_CHECKING:
+    from xlsform_validator.odk_validate.utils import PopenResult
+
+BINARY_NAME = "validate"
+CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+ODK_VALIDATE_PATH = os.path.join(CURRENT_DIRECTORY, "bin", BINARY_NAME)
+
+
+class ODKValidateError(Exception):
+    """ODK Validation exception error."""
+
+
+def install_exists():
+    """Returns True if ODK_VALIDATE_PATH exists."""
+    return os.path.exists(ODK_VALIDATE_PATH)
+
+
+def _call_validator(path_to_xform, answers, bin_file_path=ODK_VALIDATE_PATH) -> "PopenResult":
+    return run_popen_with_timeout([bin_file_path, "-x", path_to_xform, "-a", answers], 100)
+
+
+def install_ok(bin_file_path=ODK_VALIDATE_PATH):
+    """
+    Check if ODK Validate functions as expected.
+    """
+    check_readable(file_path=XFORM_SPEC_PATH)
+    result = _call_validator(
+        path_to_xform=XFORM_SPEC_PATH,
+        answers="{}",
+        bin_file_path=bin_file_path,
+    )
+    if result.return_code == 1:
+        return False
+
+    return True
+
+
+def check_xform(path_to_xform, answers):
+    """Run ODK Validate against the XForm in `path_to_xform`."""
+    # resultcode indicates validity of the form
+    # timeout indicates whether validation ran out of time to complete
+    # stdout is not used because it has some warnings that always
+    # appear and can be ignored.
+    # stderr is treated as a warning if the form is valid or an error
+    # if it is invalid.
+    result = _call_validator(path_to_xform=path_to_xform, answers=answers)
+
+    if result.timeout:
+        return ["XForm took to long to completely validate."]
+    elif result.return_code > 0:  # Error invalid
+        raise ODKValidateError(result.stderr)
+    elif result.return_code < 0:
+        return ["Bad return code from ODK Validate."]
+
+    return result.stdout
+
+
+if __name__ == "__main__":
+    logger = logging.getLogger(__name__)
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.INFO)
+    logger.info(__doc__)
+
+    check_xform(sys.argv[1], sys.argv[2])

--- a/xlsform_validator/odk_validate/utils.py
+++ b/xlsform_validator/odk_validate/utils.py
@@ -1,0 +1,127 @@
+"""
+The validators utility functions.
+"""
+
+import logging
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from subprocess import PIPE, Popen
+from typing import NamedTuple
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+XFORM_SPEC_PATH = os.path.join(HERE, "xlsform_spec_test.xml")
+
+
+class PopenResult:
+    """Result data for run_popen_with_timeout"""
+
+    def __init__(
+        self, return_code: int, timeout: bool, stdout: bytes, stderr: bytes
+    ) -> None:
+        self.return_code: int = return_code
+        self.timeout: bool = timeout
+        self.stdout: str = decode_stream(stream=stdout)
+        self.stderr: str = decode_stream(stream=stderr)
+
+
+# Adapted from:
+# http://betabug.ch/blogs/ch-athens/1093
+def run_popen_with_timeout(command, timeout) -> "PopenResult":
+    """
+    Run a sub-program in subprocess.Popen, pass it the input_data,
+    kill it if the specified timeout has passed.
+    returns a tuple of resultcode, timeout, stdout, stderr
+    """
+    kill_check = threading.Event()
+
+    def _kill_process_after_a_timeout(pid):
+        os.kill(pid, signal.SIGTERM)
+        kill_check.set()  # tell the main routine that we had to kill
+        # use SIGKILL if hard to kill...
+
+    startup_info = None
+    env = None
+    if os.name == "nt":
+        # Workarounds for pyinstaller
+        # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-subprocess
+        # disable command window when run from pyinstaller
+        startup_info = subprocess.STARTUPINFO()
+        # Less fancy version of bitwise-or-assignment (x |= y) shown in ref url.
+        if startup_info.dwFlags == 1 or subprocess.STARTF_USESHOWWINDOW == 1:
+            startup_info.dwFlags = 1
+        else:
+            startup_info.dwFlags = 0
+
+        # Workaround for Java sometimes not being able to use the temp directory.
+        # https://docs.oracle.com/javase/8/docs/api/java/io/File.html
+        # CreateTempFile refers to "java.io.tmpdir" which refers to env vars.
+        env = {
+            k: v if v is not None else tempfile.gettempdir()
+            for k, v in {k: os.environ.get(k) for k in ("TEMP", "TMP", "TMPDIR")}.items()
+        }
+
+    p = Popen(
+        command, env=env, stdin=PIPE, stdout=PIPE, stderr=PIPE, startupinfo=startup_info
+    )
+    watchdog = threading.Timer(timeout, _kill_process_after_a_timeout, args=(p.pid,))
+    watchdog.start()
+    (stdout, stderr) = p.communicate()
+    watchdog.cancel()  # if it's still waiting to run
+    timeout = kill_check.is_set()
+    kill_check.clear()
+    return PopenResult(
+        return_code=p.returncode, timeout=timeout, stdout=stdout, stderr=stderr
+    )
+
+
+def decode_stream(stream):
+    """
+    Decode a stream, e.g. stdout or stderr.
+
+    On Windows, stderr may be latin-1; in which case utf-8 decode will fail.
+    If both utf-8 and latin-1 decoding fail then raise all as IOError.
+    If the above validate jar call fails, add make sure that the java path
+    is set, e.g. PATH=C:\\Program Files (x86)\\Java\\jre1.8.0_71\\bin
+    """
+    try:
+        return stream.decode("utf-8")
+    except UnicodeDecodeError as ude:
+        try:
+            return stream.decode("latin-1")
+        except BaseException as be:
+            msg = "Failed to decode validate stderr as utf-8 or latin-1."
+            raise OSError(msg, ude, be) from be
+
+def check_readable(file_path, retry_limit=10, wait_seconds=0.5):
+    """
+    Check if a file is readable: True if so, IOError if not. Retry as per args.
+
+    If a file that needs to be read may be locked by some other process (such
+    as for reading or writing), this can help avoid an error by waiting for the
+    lock to clear.
+
+    :param file_path: Path to file to check.
+    :param retry_limit: Number of attempts to read the file.
+    :param wait_seconds: Amount of sleep time between read attempts.
+    :return: True or raise IOError.
+    """
+
+    def catch_try():
+        try:
+            with open(file_path):
+                return True
+        except OSError:
+            return False
+
+    tries = 0
+    while not catch_try():
+        if tries < retry_limit:
+            tries += 1
+            time.sleep(wait_seconds)
+        else:
+            raise OSError(f"Could not read file: {file_path}")
+    return True

--- a/xlsform_validator/odk_validate/xlsform_spec_test.xml
+++ b/xlsform_validator/odk_validate/xlsform_spec_test.xml
@@ -1,0 +1,934 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>Spec test</h:title>
+        <model odk:xforms-version="1.0.0">
+            <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="post"/>
+            <itext>
+                <translation default="true()" lang="default">
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/image_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/_1:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/end_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/today_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/audio_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+                        <value>The goal of this test is to try out all the different media types in many languages to see if there are any bugs inserting media.</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/email_note:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label">
+                        <value form="image">jr://images/a.jpg</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label">
+                        <value form="image">jr://images/b.jpg</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label">
+                        <value form="image">jr://images/b.jpg</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/time_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+                        <value form="image">jr://images/img_test.jpg</value>
+                        <value form="audio">jr://audio/audio_test.wav</value>
+                        <value form="video">jr://video/test.mov</value>
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/display_image_test:label">
+                        <value form="image">jr://images/img_test.jpg</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/date_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/barcode_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/launch:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label">
+                        <value form="image">jr://images/a.jpg</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/number_label:hint">
+                        <value>a note</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/video_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/note_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/number_label:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/FALSE:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
+                        <value>No</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/geopoint_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/a_decimal:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/my_name:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/datetime_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:hint">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
+                        <value>Yes</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/acknowledge_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/invalid_variable:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/a_integer:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/start_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
+                        <value>-</value>
+                    </text>
+                </translation>
+                <translation lang="chinese">
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/image_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/_1:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/end_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/today_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/audio_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+                        <value>ni hao</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/display_image_test:label"/>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label"/>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label"/>
+                    <text id="/xlsform_spec_test/everything/time_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+                        <value form="audio">jr://audio/chinese_audio.wav</value>
+                        <value>您好</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/email_note:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/date_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/barcode_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/launch:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label"/>
+                    <text id="/xlsform_spec_test/everything/number_label:hint">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/video_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:label">
+                        <value>您好</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/note_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+                        <value>對不起 <output value=" /xlsform_spec_test/everything/my_name "/>，你可以不選擇"是"和"否"。</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/number_label:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/FALSE:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
+                        <value>没有</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/geopoint_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/a_decimal:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label"/>
+                    <text id="/xlsform_spec_test/everything/my_name:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/datetime_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:hint">
+                        <value>ni hao</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
+                        <value>是</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/acknowledge_test:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/invalid_variable:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/a_integer:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/start_test_output:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
+                        <value>-</value>
+                    </text>
+                </translation>
+                <translation lang="english">
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/_1:label">
+                        <value>numerical name test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+                        <value>deviceid_test_output: <output value=" /xlsform_spec_test/everything/uri_deviceid "/></value></text>
+                    <text id="/xlsform_spec_test/skip_to_end/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/end_test_output:label">
+                        <value>end test output: <output value=" /xlsform_spec_test/everything/end "/></value></text>
+                    <text id="/xlsform_spec_test/everything/today_test_output:label">
+                        <value>today_test_output: <output value=" /xlsform_spec_test/everything/today "/></value></text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+                        <value><output value=" /xlsform_spec_test/everything/calculate_test "/></value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/image_test:label">
+                        <value>image_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+                        <value>autocomplete_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+                        <value>list-nolabel-test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label"/>
+                    <text id="/xlsform_spec_test/everything/note_test:label">
+                        <value>note_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/time_test:label">
+                        <value>time_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+                        <value>deviceid_test_output: <output value=" /xlsform_spec_test/everything/deviceid "/></value></text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+                        <value form="image">jr://images/img_test_2.jpg</value>
+                        <value>text_image_audio_video_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end:label">
+                        <value>Skip to end</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/audio_test:label">
+                        <value>audio_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/email_note:label">
+                        <value>You entered an email address</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/date_test:label">
+                        <value>date_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+                        <value>select multiple test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/barcode_test:label">
+                        <value>barcode_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/launch:label">
+                        <value>This launches a fictional application to get an integer result.</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label"/>
+                    <text id="/xlsform_spec_test/everything/number_label:hint">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/video_test:label">
+                        <value>video_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label"/>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/datetime_test:label">
+                        <value>datetime_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/skip_to_end/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+                        <value>autocomplete_chars_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+                        <value>Sorry <output value=" /xlsform_spec_test/everything/my_name "/>, you can't select yes and no.</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/number_label:label">
+                        <value>1</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+                        <value>table list question</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test:label">
+                        <value>repeat_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/FALSE:label">
+                        <value>boolean name test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
+                        <value>compact-2-test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/geopoint_test:label">
+                        <value>geopoint_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/a_decimal:label">
+                        <value>constrained decimal</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+                        <value>required_text</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/my_name:label">
+                        <value>Enter your name</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+                        <value>phonenumber_test_output: <output value=" /xlsform_spec_test/everything/phonenumber "/></value></text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+                        <value>label-test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:label">
+                        <value>Enter an address</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
+                        <value>labeled select group test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/address:hint">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
+                        <value>-</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/acknowledge_test:label">
+                        <value>acknowledge_test</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/display_image_test:label"/>
+                    <text id="/xlsform_spec_test/everything/invalid_variable:label">
+                        <value>Your name is <output value=" /xlsform_spec_test/everything/my_name "/></value></text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label"/>
+                    <text id="/xlsform_spec_test/everything/a_integer:label">
+                        <value>a integer</value>
+                    </text>
+                    <text id="/xlsform_spec_test/everything/start_test_output:label">
+                        <value>start test output: <output value=" /xlsform_spec_test/everything/start "/></value></text>
+                    <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
+                        <value>compact-test</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <xlsform_spec_test id="Spec test">
+                    <skip_to_end/>
+                    <everything>
+                        <my_name/>
+                        <invalid_variable/>
+                        <address/>
+                        <email_note/>
+                        <number_label/>
+                        <text_image_audio_video_test/>
+                        <display_image_test/>
+                        <autocomplete_test/>
+                        <autocomplete_chars_test/>
+                        <a_integer/>
+                        <a_decimal/>
+                        <repeat_test_count/>
+                        <repeat_test jr:template="">
+                            <group_test>
+                                <required_text/>
+                                <select_multiple_test/>
+                            </group_test>
+                            <labeled_select_group>
+                                <label-test/>
+                                <list-nolabel-test/>
+                            </labeled_select_group>
+                            <name>
+                                <reserved_name_for_field_list_labels_25/>
+                                <table_list_question/>
+                            </name>
+                            <compact-test/>
+                            <compact-2-test/>
+                        </repeat_test>
+                        <repeat_test>
+                            <group_test>
+                                <required_text/>
+                                <select_multiple_test/>
+                            </group_test>
+                            <labeled_select_group>
+                                <label-test/>
+                                <list-nolabel-test/>
+                            </labeled_select_group>
+                            <name>
+                                <reserved_name_for_field_list_labels_25/>
+                                <table_list_question/>
+                            </name>
+                            <compact-test/>
+                            <compact-2-test/>
+                        </repeat_test>
+                        <acknowledge_test/>
+                        <date_test/>
+                        <time_test/>
+                        <datetime_test/>
+                        <geopoint_test/>
+                        <barcode_test/>
+                        <image_test/>
+                        <audio_test/>
+                        <video_test/>
+                        <note_test/>
+                        <calculate_test/>
+                        <calculate_test_output/>
+                        <start/>
+                        <start_test_output/>
+                        <end/>
+                        <end_test_output/>
+                        <today/>
+                        <today_test_output/>
+                        <deviceid/>
+                        <deviceid_test_output/>
+                        <uri_deviceid/>
+                        <uri_deviceid_test_output/>
+                        <phonenumber/>
+                        <phonenumber_test_output/>
+                        <_1/>
+                        <FALSE/>
+                    </everything>
+                    <launch/>
+                    <meta>
+                        <instanceID/>
+                        <instanceName/>
+                    </meta>
+                </xlsform_spec_test>
+            </instance>
+            <bind nodeset="/xlsform_spec_test/skip_to_end" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything" relevant="not(selected( /xlsform_spec_test/skip_to_end , 'yes'))"/>
+            <bind nodeset="/xlsform_spec_test/everything/my_name" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/invalid_variable" readonly="true()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/address" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/email_note" readonly="true()" relevant="regex( /xlsform_spec_test/everything/address , '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}')" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/number_label" readonly="true()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/text_image_audio_video_test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/display_image_test" readonly="true()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/autocomplete_test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/autocomplete_chars_test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/a_integer" type="int"/>
+            <bind constraint=". &lt;=  /xlsform_spec_test/everything/a_integer " nodeset="/xlsform_spec_test/everything/a_decimal" type="decimal"/>
+            <bind calculate="2" nodeset="/xlsform_spec_test/everything/repeat_test_count" readonly="true()" type="string"/>
+            <bind jr:requiredMsg="Custom required message." nodeset="/xlsform_spec_test/everything/repeat_test/group_test/required_text" required="true()" type="string"/>
+            <bind constraint="not(selected(., 'yes') and selected (., 'no'))" jr:constraintMsg="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg')" nodeset="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test" required="false()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test" required="true()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/name/table_list_question" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/compact-test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/repeat_test/compact-2-test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/acknowledge_test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/date_test" type="date"/>
+            <bind nodeset="/xlsform_spec_test/everything/time_test" type="time"/>
+            <bind nodeset="/xlsform_spec_test/everything/datetime_test" type="dateTime"/>
+            <bind nodeset="/xlsform_spec_test/everything/geopoint_test" type="geopoint"/>
+            <bind nodeset="/xlsform_spec_test/everything/barcode_test" type="barcode"/>
+            <bind nodeset="/xlsform_spec_test/everything/image_test" type="binary"/>
+            <bind nodeset="/xlsform_spec_test/everything/audio_test" type="binary"/>
+            <bind nodeset="/xlsform_spec_test/everything/video_test" type="binary"/>
+            <bind nodeset="/xlsform_spec_test/everything/note_test" readonly="true()" type="string"/>
+            <bind calculate="2+2" nodeset="/xlsform_spec_test/everything/calculate_test" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/calculate_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="timestamp" jr:preloadParams="start" nodeset="/xlsform_spec_test/everything/start" type="dateTime"/>
+            <bind nodeset="/xlsform_spec_test/everything/start_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="timestamp" jr:preloadParams="end" nodeset="/xlsform_spec_test/everything/end" type="dateTime"/>
+            <bind nodeset="/xlsform_spec_test/everything/end_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="date" jr:preloadParams="today" nodeset="/xlsform_spec_test/everything/today" type="date"/>
+            <bind nodeset="/xlsform_spec_test/everything/today_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="property" jr:preloadParams="deviceid" nodeset="/xlsform_spec_test/everything/deviceid" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/deviceid_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="property" jr:preloadParams="uri:deviceid" nodeset="/xlsform_spec_test/everything/uri_deviceid" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/uri_deviceid_test_output" readonly="true()" type="string"/>
+            <bind jr:preload="property" jr:preloadParams="phonenumber" nodeset="/xlsform_spec_test/everything/phonenumber" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/phonenumber_test_output" readonly="true()" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/_1" type="string"/>
+            <bind nodeset="/xlsform_spec_test/everything/FALSE" type="string"/>
+            <bind jr:noAppErrorString="Sorry, app does not exist." nodeset="/xlsform_spec_test/launch" type="int"/>
+            <bind jr:preload="uid" nodeset="/xlsform_spec_test/meta/instanceID" readonly="true()" type="string"/>
+            <bind calculate=" /xlsform_spec_test/everything/my_name " nodeset="/xlsform_spec_test/meta/instanceName" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/xlsform_spec_test/skip_to_end">
+            <label ref="jr:itext('/xlsform_spec_test/skip_to_end:label')"/>
+            <item>
+                <label ref="jr:itext('/xlsform_spec_test/skip_to_end/yes:label')"/>
+                <value>yes</value>
+            </item>
+            <item>
+                <label ref="jr:itext('/xlsform_spec_test/skip_to_end/no:label')"/>
+                <value>no</value>
+            </item>
+        </select1>
+        <group ref="/xlsform_spec_test/everything">
+            <input ref="/xlsform_spec_test/everything/my_name" rows="12">
+                <label ref="jr:itext('/xlsform_spec_test/everything/my_name:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/invalid_variable">
+                <label ref="jr:itext('/xlsform_spec_test/everything/invalid_variable:label')"/>
+                <hint>Try replacing my_name with a invalid variable</hint>
+            </input>
+            <input ref="/xlsform_spec_test/everything/address">
+                <label ref="jr:itext('/xlsform_spec_test/everything/address:label')"/>
+                <hint ref="jr:itext('/xlsform_spec_test/everything/address:hint')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/email_note">
+                <label ref="jr:itext('/xlsform_spec_test/everything/email_note:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/number_label">
+                <label ref="jr:itext('/xlsform_spec_test/everything/number_label:label')"/>
+                <hint ref="jr:itext('/xlsform_spec_test/everything/number_label:hint')"/>
+            </input>
+            <input autoplay="audio" ref="/xlsform_spec_test/everything/text_image_audio_video_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/text_image_audio_video_test:label')"/>
+                <hint ref="jr:itext('/xlsform_spec_test/everything/text_image_audio_video_test:hint')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/display_image_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/display_image_test:label')"/>
+            </input>
+            <select1 appearance="autocomplete" ref="/xlsform_spec_test/everything/autocomplete_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test:label')"/>
+                <item>
+                    <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test/yes:label')"/>
+                    <value>yes</value>
+                </item>
+                <item>
+                    <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test/no:label')"/>
+                    <value>no</value>
+                </item>
+            </select1>
+            <select1 appearance="autocomplete_chars" ref="/xlsform_spec_test/everything/autocomplete_chars_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test:label')"/>
+                <item>
+                    <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test/yes:label')"/>
+                    <value>yes</value>
+                </item>
+                <item>
+                    <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test/no:label')"/>
+                    <value>no</value>
+                </item>
+            </select1>
+            <input ref="/xlsform_spec_test/everything/a_integer">
+                <label ref="jr:itext('/xlsform_spec_test/everything/a_integer:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/a_decimal">
+                <label ref="jr:itext('/xlsform_spec_test/everything/a_decimal:label')"/>
+            </input>
+            <group ref="/xlsform_spec_test/everything/repeat_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test:label')"/>
+                <repeat jr:count=" /xlsform_spec_test/everything/repeat_test_count " nodeset="/xlsform_spec_test/everything/repeat_test">
+                    <group appearance="field-list" ref="/xlsform_spec_test/everything/repeat_test/group_test">
+                        <input ref="/xlsform_spec_test/everything/repeat_test/group_test/required_text">
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/required_text:label')"/>
+                        </input>
+                        <select appearance="minimal" ref="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test">
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label')"/>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label')"/>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label')"/>
+                                <value>no</value>
+                            </item>
+                        </select>
+                    </group>
+                    <group appearance="field-list" ref="/xlsform_spec_test/everything/repeat_test/labeled_select_group">
+                        <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group:label')"/>
+                        <select1 appearance="label" ref="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test">
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label')"/>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label')"/>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label')"/>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 appearance="list-nolabel" ref="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test">
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label')"/>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label')"/>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label')"/>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                    </group>
+                    <group appearance="field-list" ref="/xlsform_spec_test/everything/repeat_test/name">
+                        <select1 appearance="label" ref="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25">
+                            <label></label>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label')"/>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label')"/>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                        <select1 appearance="list-nolabel" ref="/xlsform_spec_test/everything/repeat_test/name/table_list_question">
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question:label')"/>
+                            <hint>hint</hint>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label')"/>
+                                <value>yes</value>
+                            </item>
+                            <item>
+                                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label')"/>
+                                <value>no</value>
+                            </item>
+                        </select1>
+                    </group>
+                    <select1 appearance="compact" ref="/xlsform_spec_test/everything/repeat_test/compact-test">
+                        <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test:label')"/>
+                        <item>
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test/a:label')"/>
+                            <value>a</value>
+                        </item>
+                        <item>
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test/b:label')"/>
+                            <value>b</value>
+                        </item>
+                    </select1>
+                    <select1 appearance="compact-2" ref="/xlsform_spec_test/everything/repeat_test/compact-2-test">
+                        <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test:label')"/>
+                        <item>
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label')"/>
+                            <value>a</value>
+                        </item>
+                        <item>
+                            <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label')"/>
+                            <value>b</value>
+                        </item>
+                    </select1>
+                </repeat>
+            </group>
+            <trigger ref="/xlsform_spec_test/everything/acknowledge_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/acknowledge_test:label')"/>
+            </trigger>
+            <input ref="/xlsform_spec_test/everything/date_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/date_test:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/time_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/time_test:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/datetime_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/datetime_test:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/geopoint_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/geopoint_test:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/barcode_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/barcode_test:label')"/>
+            </input>
+            <upload mediatype="image/*" ref="/xlsform_spec_test/everything/image_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/image_test:label')"/>
+            </upload>
+            <upload mediatype="audio/*" ref="/xlsform_spec_test/everything/audio_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/audio_test:label')"/>
+            </upload>
+            <upload mediatype="video/*" ref="/xlsform_spec_test/everything/video_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/video_test:label')"/>
+            </upload>
+            <input ref="/xlsform_spec_test/everything/note_test">
+                <label ref="jr:itext('/xlsform_spec_test/everything/note_test:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/calculate_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/calculate_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/start_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/start_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/end_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/end_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/today_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/today_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/deviceid_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/deviceid_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/uri_deviceid_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/uri_deviceid_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/phonenumber_test_output">
+                <label ref="jr:itext('/xlsform_spec_test/everything/phonenumber_test_output:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/_1">
+                <label ref="jr:itext('/xlsform_spec_test/everything/_1:label')"/>
+            </input>
+            <input ref="/xlsform_spec_test/everything/FALSE">
+                <label ref="jr:itext('/xlsform_spec_test/everything/FALSE:label')"/>
+            </input>
+        </group>
+        <input appearance="ex:org.thirdparty.app.ActivityName" ref="/xlsform_spec_test/launch">
+            <label ref="jr:itext('/xlsform_spec_test/launch:label')"/>
+        </input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
I created an executable binary using GraalVM around JavaRosa to validate and generate instances instead of reimplementing the validation logic ourselves.

The logic to use the binary file is heavily inspired from [pyxform's wrapper](https://github.com/XLSForm/pyxform/tree/master/pyxform/validators/odk_validate) around [getODK/Validate](https://github.com/getodk/validate).